### PR TITLE
[AB#6036] feat(server): configuration before docker

### DIFF
--- a/LensmaniaServer/Program.cs
+++ b/LensmaniaServer/Program.cs
@@ -5,6 +5,7 @@ using LensmaniaServer.Models;
 using LensmaniaServer.Errors;
 using LensmaniaServer.Options;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
@@ -109,17 +110,28 @@ builder.Services.AddScoped<GoogleAuthService>();
 builder.Services.AddScoped<IGoogleTokenValidator, GoogleTokenValidator>();
 builder.Services.AddSingleton<TokenService>();
 
+var allowedOrigins = builder.Configuration
+    .GetSection("Cors:AllowedOrigins").Get<string[]>()
+    ?? ["http://localhost:5135"];
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowClient", policy =>
     {
-        policy.WithOrigins("http://localhost:5135")
+        policy.WithOrigins(allowedOrigins)
             .AllowAnyHeader()
             .AllowAnyMethod();
     });
 });
 
 var app = builder.Build();
+
+// Derrière un reverse proxy (nginx), prendre en compte les en-têtes transmis
+// (protocole/IP d'origine) avant tout le reste du pipeline.
+app.UseForwardedHeaders(new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto
+});
 
 if (app.Environment.IsDevelopment()) {
     app.MapOpenApi();

--- a/LensmaniaServer/appsettings.example.json
+++ b/LensmaniaServer/appsettings.example.json
@@ -26,5 +26,8 @@
   },
   "Google": {
     "ClientId": "YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com"
+  },
+  "Cors": {
+    "AllowedOrigins": [ "http://localhost:5135" ]
   }
 }


### PR DESCRIPTION
make CORS origins configurable and honor proxy forwarded headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced infrastructure to properly handle reverse proxy forwarded headers in the request pipeline
  * Transitioned CORS (Cross-Origin Resource Sharing) allowed origins configuration from hardcoded values to flexible application settings, with http://localhost:5135 as the default fallback
  * Updated example configuration file to include the new CORS settings section for easier deployment customization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->