### PR TITLE
[AB#6036] feat(docker): add containerization for client, server and postgres 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# .dockerignore
+**/bin/
+**/obj/
+**/.vs/
+**/.idea/
+**/node_modules/
+**/.git/
+**/.gitignore
+**/*.user
+# Ne jamais embarquer de secrets ni de config locale dans l'image
+**/appsettings.Development.json
+LensmaniaServer/appsettings.json
+# Donnees utilisateurs : restent dans un volume, pas dans l'image
+**/wwwroot/uploads/photos/*
+docs/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# .env.example — modele de configuration Docker.
+# Copier en .env puis renseigner les valeurs : cp .env.example .env
+# (le .env reel ne doit JAMAIS etre committe : il contient les secrets)
+
+# --- PostgreSQL ---
+POSTGRES_DB=lensmania_db
+POSTGRES_USER=lensmania
+POSTGRES_PASSWORD=change-me-strong-password
+
+# --- API (la convention __ remplace le : de la hierarchie de config ASP.NET) ---
+# IMPORTANT : le mot de passe ci-dessous doit etre identique a POSTGRES_PASSWORD.
+ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=lensmania_db;Username=lensmania;Password=change-me-strong-password
+Jwt__Key=change-me-random-key-min-32-chars
+Jwt__Issuer=LensmaniaServer
+Jwt__Audience=LensmaniaClient
+Jwt__ExpirationMinutes=60
+
+# Email : compte Gmail + mot de passe d'application (2FA active).
+Email__SmtpHost=smtp.gmail.com
+Email__SmtpPort=587
+Email__UseStartTls=true
+Email__FromAddress=your-account@gmail.com
+Email__FromDisplayName=Lensmania
+Email__Username=your-account@gmail.com
+Email__Password=your-gmail-app-password
+
+PasswordReset__TokenLifetimeMinutes=60
+PasswordReset__ClientBaseUrl=http://localhost:8080
+EventClosing__IntervalSeconds=60
+Google__ClientId=YOUR_GOOGLE_CLIENT_ID.apps.googleusercontent.com

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # dotenv files
 .env
 .env.*
+!.env.example
 
 # User-specific files
 *.rsuser

--- a/LensmaniaClient/Dockerfile
+++ b/LensmaniaClient/Dockerfile
@@ -1,0 +1,18 @@
+﻿# ---------- Étape 1 : build WASM ----------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY LensmaniaLibrary/LensmaniaLibrary.csproj LensmaniaLibrary/
+COPY LensmaniaClient/LensmaniaClient.csproj   LensmaniaClient/
+RUN dotnet restore LensmaniaClient/LensmaniaClient.csproj
+
+COPY LensmaniaLibrary/ LensmaniaLibrary/
+COPY LensmaniaClient/  LensmaniaClient/
+RUN dotnet publish LensmaniaClient/LensmaniaClient.csproj -c Release -o /app/publish
+
+# ---------- Étape 2 : serveur web statique ----------
+FROM nginx:1.27-alpine AS final
+# Les fichiers publiés du WASM se trouvent dans publish/wwwroot.
+COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
+COPY LensmaniaClient/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/LensmaniaClient/Dockerfile
+++ b/LensmaniaClient/Dockerfile
@@ -1,4 +1,4 @@
-﻿# ---------- Étape 1 : build WASM ----------
+# ---------- Étape 1 : build WASM ----------
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
@@ -10,9 +10,11 @@ COPY LensmaniaLibrary/ LensmaniaLibrary/
 COPY LensmaniaClient/  LensmaniaClient/
 RUN dotnet publish LensmaniaClient/LensmaniaClient.csproj -c Release -o /app/publish
 
-# ---------- Étape 2 : serveur web statique ----------
-FROM nginx:1.27-alpine AS final
+# ---------- Étape 2 : serveur web statique (nginx non-root) ----------
+# Image officielle "unprivileged" : tourne en USER 101 (nginx) et ecoute sur 8080,
+# sans process maitre root ni soucis de droits sur le PID / le cache.
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS final
 # Les fichiers publiés du WASM se trouvent dans publish/wwwroot.
 COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
 COPY LensmaniaClient/nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+EXPOSE 8080

--- a/LensmaniaClient/appsettings.Docker.json
+++ b/LensmaniaClient/appsettings.Docker.json
@@ -1,0 +1,8 @@
+{
+  "Api": {
+    "BaseUrl": "http://localhost:8080/"
+  },
+  "Google": {
+    "ClientId": "928641457475-emjogsc6avi1vkc3co8dbdc9tdu8o17f.apps.googleusercontent.com"
+  }
+}

--- a/LensmaniaClient/nginx.conf
+++ b/LensmaniaClient/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;

--- a/LensmaniaClient/nginx.conf
+++ b/LensmaniaClient/nginx.conf
@@ -1,0 +1,44 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    client_max_body_size 20m;   
+
+
+    location /api/ {
+        proxy_pass http://server:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /uploads/ {
+        proxy_pass http://server:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location /openapi/ {
+        proxy_pass http://server:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+
+    location / {
+        try_files $uri $uri/ /index.html =404;
+    }
+
+    gzip on;
+    gzip_types text/plain text/css application/javascript application/json
+               application/wasm application/octet-stream;
+
+
+    location /_framework/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/LensmaniaServer/Dockerfile
+++ b/LensmaniaServer/Dockerfile
@@ -13,6 +13,11 @@ RUN dotnet publish LensmaniaServer/LensmaniaServer.csproj \
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
+# curl sert uniquement au HEALTHCHECK du conteneur (image runtime sans client HTTP).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 EXPOSE 8080
 ENV ASPNETCORE_HTTP_PORTS=8080
 

--- a/LensmaniaServer/Dockerfile
+++ b/LensmaniaServer/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY LensmaniaLibrary/LensmaniaLibrary.csproj LensmaniaLibrary/
+COPY LensmaniaServer/LensmaniaServer.csproj   LensmaniaServer/
+RUN dotnet restore LensmaniaServer/LensmaniaServer.csproj
+
+COPY LensmaniaLibrary/ LensmaniaLibrary/
+COPY LensmaniaServer/  LensmaniaServer/
+RUN dotnet publish LensmaniaServer/LensmaniaServer.csproj \
+    -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
+WORKDIR /app
+
+EXPOSE 8080
+ENV ASPNETCORE_HTTP_PORTS=8080
+
+RUN mkdir -p /app/wwwroot/uploads/photos
+
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "LensmaniaServer.dll"]

--- a/LensmaniaServer/Dockerfile
+++ b/LensmaniaServer/Dockerfile
@@ -21,7 +21,13 @@ RUN apt-get update \
 EXPOSE 8080
 ENV ASPNETCORE_HTTP_PORTS=8080
 
-RUN mkdir -p /app/wwwroot/uploads/photos
+# Le dossier des uploads doit appartenir a l'utilisateur applicatif (APP_UID)
+# pour qu'il puisse y ecrire les photos une fois le process en non-root.
+RUN mkdir -p /app/wwwroot/uploads/photos \
+    && chown -R $APP_UID:$APP_UID /app/wwwroot/uploads
 
 COPY --from=build /app/publish .
+
+# On execute le process en non-root (utilisateur "app" fourni par l'image aspnet).
+USER $APP_UID
 ENTRYPOINT ["dotnet", "LensmaniaServer.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      # Le client n'est lance qu'une fois l'API prete a repondre.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 40s
     volumes:
       # Les photos uploadees doivent survivre a la recreation du conteneur.
       - uploads:/app/wwwroot/uploads/photos
@@ -40,7 +47,8 @@ services:
       dockerfile: LensmaniaClient/Dockerfile
     restart: unless-stopped
     depends_on:
-      - server
+      server:
+        condition: service_healthy
     volumes:
       # Surcharge l'URL de l'API sans rebuild ni toucher au appsettings.json
       # committe (qui reste cale sur le dev direct localhost:5078).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  db:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - pgdata:/var/lib/postgresql
+    healthcheck:
+      # On ne demarre l'API que lorsque la base accepte les connexions.
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  server:
+    build:
+      context: .
+      dockerfile: LensmaniaServer/Dockerfile
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      # Les photos uploadees doivent survivre a la recreation du conteneur.
+      - uploads:/app/wwwroot/uploads/photos
+    # L'API n'est joignable que par le client via le reseau interne.
+    # Decommenter pour taper l'API directement depuis l'hote (debug).
+    # ports:
+    #   - "127.0.0.1:8081:8080"
+
+  client:
+    build:
+      context: .
+      dockerfile: LensmaniaClient/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      - server
+    volumes:
+      # Surcharge l'URL de l'API sans rebuild ni toucher au appsettings.json
+      # committe (qui reste cale sur le dev direct localhost:5078).
+      - ./LensmaniaClient/appsettings.Docker.json:/usr/share/nginx/html/appsettings.json:ro
+    ports:
+      - "8080:80"     # le client (et l'API via proxy) sur http://localhost:8080
+
+volumes:
+  pgdata:
+  uploads:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       # committe (qui reste cale sur le dev direct localhost:5078).
       - ./LensmaniaClient/appsettings.Docker.json:/usr/share/nginx/html/appsettings.json:ro
     ports:
-      - "8080:80"     # le client (et l'API via proxy) sur http://localhost:8080
+      - "8080:8080"   # le client (et l'API via proxy) sur http://localhost:8080
 
 volumes:
   pgdata:


### PR DESCRIPTION
compose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Docker containerization for both client and server using multi-stage builds, including nginx-based static hosting and API routing.
  * Introduced a Docker Compose setup for local development with service healthchecks, environment templates, and persistent storage for PostgreSQL and uploads.
  * Added Docker-focused configuration (nginx rules, client override app settings, and a Docker build context ignore file) plus an updated `.env.example`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->